### PR TITLE
スムーススクロールのcssをminからmaxへ修正

### DIFF
--- a/wagyu_price/css/style.css
+++ b/wagyu_price/css/style.css
@@ -33,11 +33,7 @@ p {
   border-radius: 0;
 }
 
-@media screen and (min-width:576px) {
-  .row {
-    margin-bottom: 30px;
-  }
-
+@media screen and (max-width:576px) {
   #page-top {
     width: 40px;
     height: 40px;


### PR DESCRIPTION
スマホのサイズで表示した時(576px未満)に、スムーススクロール出るようになりました。